### PR TITLE
Quadborg Guidebook and GuideHelp components 

### DIFF
--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -58,6 +58,7 @@ guide-entry-traversal-distorter = Traversal Distorter
 guide-entry-machine-upgrading = Machine Upgrading
 guide-entry-robotics = Robotics
 guide-entry-cyborgs = Cyborgs
+guide-entry-quadborgs = Quadborgs
 guide-entry-security = Security
 guide-entry-forensics = Forensics
 guide-entry-defusal = Large Bomb Defusal

--- a/Resources/Prototypes/Floof/Entities/Mobs/Cyborgs/quadborg.yml
+++ b/Resources/Prototypes/Floof/Entities/Mobs/Cyborgs/quadborg.yml
@@ -53,6 +53,11 @@
   - type: SiliconLawProvider
     laws: Qborg
   - type: LeashAnchor # Floofstation
+  - type: GuideHelp
+    guides:
+    - Quadborgs
+    - Cyborgs
+
 
 - type: entity
   id: BorgChassisQuadCC

--- a/Resources/Prototypes/Floof/Entities/Objects/Specific/Robotics/Borgmodules.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Specific/Robotics/Borgmodules.yml
@@ -6,6 +6,10 @@
   - type: Tag
     tags:
     - BorgModuleSecurity
+  - type: GuideHelp
+    guides:
+    - Quadborgs
+    - Cyborgs
 
 - type: entity
   id: BorgModuleStun
@@ -24,6 +28,10 @@
     - BorgStunbaton
     - BorgFlash
     - BorgZipties
+  - type: GuideHelp
+    guides:
+    - Quadborgs
+    - Cyborgs
 
 - type: entity
   id: BorgModuleKill
@@ -40,6 +48,10 @@
     - WeaponAdvancedLaser
     - WeaponborgPistolMk58
     - CombatKnife
+  - type: GuideHelp
+    guides:
+    - Quadborgs
+    - Cyborgs
 
 - type: entity
   id: BorgModuleInvestigation
@@ -56,6 +68,10 @@
     - ForensicScanner
     - DetectivePDA
     - SecurityWhistle
+  - type: GuideHelp
+    guides:
+    - Quadborgs
+    - Cyborgs
 
 - type: entity
   id: BorgModuleadvancedmeasures
@@ -71,4 +87,8 @@
     items:
     - WeaponBorgEnergyShotgun
     - BorgWeaponXrayCannon
+  - type: GuideHelp
+    guides:
+    - Quadborgs
+    - Cyborgs
 

--- a/Resources/Prototypes/Floof/Entities/Objects/Specific/Robotics/endoskeleton.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Specific/Robotics/endoskeleton.yml
@@ -147,3 +147,7 @@
     containers:
     - part-container
     - cell_slot
+  - type: GuideHelp
+    guides:
+    - Quadborgs
+    - Cyborgs

--- a/Resources/Prototypes/Guidebook/science.yml
+++ b/Resources/Prototypes/Guidebook/science.yml
@@ -70,6 +70,13 @@
   id: Cyborgs
   name: guide-entry-cyborgs
   text: "/ServerInfo/Guidebook/Science/Cyborgs.xml"
+  children:
+  - Quadborgs
+
+- type: guideEntry
+  id: Quadborgs
+  name: guide-entry-quadborgs
+  text: "/ServerInfo/Guidebook/Science/Quadborgs.xml"
 
 - type: guideEntry
   id: GlimmerCreatures

--- a/Resources/ServerInfo/Guidebook/Science/Quadborgs.xml
+++ b/Resources/ServerInfo/Guidebook/Science/Quadborgs.xml
@@ -1,0 +1,44 @@
+<Document>
+  # Quadborgs
+  Quadborgs are the quadruped variant of [textlink="cyborgs" link="Cyborgs"]. They function virtually the same, and are also bound by [color=cyan]silicon law.[/color] The only major differences are the material cost, appearance, ability to serve in the security department as a silicon, and lack of a Generic, Janitorial, and Engineering chassis.
+
+  ## Endoskeleton
+  <Box>
+  <GuideEntityEmbed Entity="Quadborgendoskeleton" Caption="Quadborg Endoskeleton"/>
+  <GuideEntityEmbed Entity="ExosuitFabricator" Caption="Exosuit Fabricator"/>
+  </Box>
+  All quadborgs start off as a four-legged endoskeleton. Much like the cyborg endoskeleton, this is crafted at the [color=#a4885c]Exosuit Fabricator[/color], and uses cyborg parts. Assembly steps can be followed by [color=#a4885c]examining[/color] the endoskeleton. 
+    
+  Once built, further upgrades such as additional tooling and better power cells can be installed later on.
+    
+  ## Chassis
+  Quadborg chassis are similiar in function to the cyborg chassis, bearing the same nuances revolving [color=#a4885c]radio communication[/color] and [color=#a4885c]all-access[/color] except command areas. [bold]Quadborg chassis can fit up to 4 modules, with exception to the Service chassis which can fit up to 6.[/bold]
+  <Box>
+  <GuideEntityEmbed Entity="BorgChassisQuadserv" Caption="Service" Rotation="270"/>
+  <GuideEntityEmbed Entity="BorgChassisQuad" Caption="Security" Rotation="270"/>
+  <GuideEntityEmbed Entity="BorgChassisQuadsalv" Caption="Salvage" Rotation="270"/>
+  <GuideEntityEmbed Entity="BorgChassisQuadmed" Caption="Medical" Rotation="270"/>
+  </Box>
+  <Box>
+  [italic]Examples of various quadborg chassis[/italic]
+  </Box>
+  If you wish to change the chassis of an already existing quadborg, you have to construct a whole new one, parts and endoskeleton included. The brain, power cell and modules [italic](if it can fit in the new chassis,)[/italic] can be carried over from the old chassis, if desired.
+
+  ## Security Quadborg
+  Unique to quadborgs is the capability to serve in the security department as a silicon. [bold]Using generic cyborg parts on a quadborg endoskeleton will construct the security chassis.[/bold]
+  <Box>
+  <GuideEntityEmbed Entity="BorgChassisQuad" Caption="Security Quadborg" Rotation="270"/>
+  <GuideEntityEmbed Entity="SecurityTechFab" Caption="Security TechFab"/>
+  </Box>
+  The security chassis can only be unlocked by security, command, or another borg. Epistemics personnel will not be able to unlock the chassis due to access restrictions. [italic](Afterall, it can fit weapons!)[/italic]
+
+  [color=#a4885c]Security cyborg modules[/color] can only be manufactured at the [color=#a4885c]security techfab[/color]. Make sure to notify your newly commissioned security quadborg of this fact to avoid confusion.
+  <Box>
+  <GuideEntityEmbed Entity="BorgModuleStun" Caption="Disabler"/>
+  <GuideEntityEmbed Entity="BorgModuleInvestigation" Caption="Investigation"/>
+  <GuideEntityEmbed Entity="BorgModuleKill" Caption="Combat"/>
+  </Box>
+  <Box>
+  [italic]Examples of security cyborg modules. Note the housing and circuit board colors.[/italic]
+  </Box>
+</Document>

--- a/Resources/ServerInfo/Guidebook/Science/Quadborgs.xml
+++ b/Resources/ServerInfo/Guidebook/Science/Quadborgs.xml
@@ -7,12 +7,12 @@
   <GuideEntityEmbed Entity="Quadborgendoskeleton" Caption="Quadborg Endoskeleton"/>
   <GuideEntityEmbed Entity="ExosuitFabricator" Caption="Exosuit Fabricator"/>
   </Box>
-  All quadborgs start off as a four-legged endoskeleton. Much like the cyborg endoskeleton, this is crafted at the [color=#a4885c]Exosuit Fabricator[/color], and uses cyborg parts. Assembly steps can be followed by [color=#a4885c]examining[/color] the endoskeleton. 
+  All quadborgs start off as a [color=#a4885c]four-legged[/color] endoskeleton. Much like the cyborg endoskeleton, this is crafted at the [color=#a4885c]Exosuit Fabricator[/color], and uses cyborg parts. Assembly steps can be followed by [color=#a4885c]examining[/color] the endoskeleton. While assembly is similiar, [bold]Quadborgs do not have arms, and instead utilize two right legs, and two left legs as part of it's construction.[/bold]
     
   Once built, further upgrades such as additional tooling and better power cells can be installed later on.
     
   ## Chassis
-  Quadborg chassis are similiar in function to the cyborg chassis, bearing the same nuances revolving [color=#a4885c]radio communication[/color] and [color=#a4885c]all-access[/color] except command areas. [bold]Quadborg chassis can fit up to 4 modules, with exception to the Service chassis which can fit up to 6.[/bold]
+  Quadborg chassis are similiar in function to the cyborg chassis, bearing the same nuances revolving [color=#a4885c]radio communication[/color] and [color=#a4885c]all-access[/color] except command areas. [bold]Quadborg chassis can fit up to 4 modules, with exception to the Service chassis which can fit up to 6,[/bold] made possible from it's [italic]"auxillary hardware"[/italic] purpose-built for it.
   <Box>
   <GuideEntityEmbed Entity="BorgChassisQuadserv" Caption="Service" Rotation="270"/>
   <GuideEntityEmbed Entity="BorgChassisQuad" Caption="Security" Rotation="270"/>
@@ -24,7 +24,7 @@
   </Box>
   If you wish to change the chassis of an already existing quadborg, you have to construct a whole new one, parts and endoskeleton included. The brain, power cell and modules [italic](if it can fit in the new chassis,)[/italic] can be carried over from the old chassis, if desired.
 
-  ## Security Quadborg
+  ## Security Applications
   Unique to quadborgs is the capability to serve in the security department as a silicon. [bold]Using generic cyborg parts on a quadborg endoskeleton will construct the security chassis.[/bold]
   <Box>
   <GuideEntityEmbed Entity="BorgChassisQuad" Caption="Security Quadborg" Rotation="270"/>


### PR DESCRIPTION
# Description

This PR is dependent on your current ["Quadborgs 3" PR](https://github.com/Fansana/floofstation1/pull/539) to Floofstation.

This is an addition of a Guidebook entry to address Quadborgs, namely `quadborgs.yml` and the necessary `GuideHelpComponent` additions to all quadborg-centric prototypes. I have decided to build on top of what you already got going in order to ensure a smooth merge on Floofstation where both of our changes gets pulled in at once, instead of waiting for it to be merged.

All I ask for is credit on the guidebook entry. Any questions, comments, or concerns, feel free to let me know.

---

# TODO

- [x] Initial Draft
- [x] First Revision, addition of `GuideHelpComponent` to relevant prototypes
- [x] Final Draft

---
<details><summary><h1>Media</h1></summary>
<p>

![Dis is one part...](https://github.com/user-attachments/assets/d54d83fd-6f4c-4e87-8823-ef2cadfd5a93)
![Dis is second part.](https://github.com/user-attachments/assets/f8c3bf4f-80b2-432c-8112-998bf9b8adf6)
![Dis is ze third, rejoice](https://github.com/user-attachments/assets/a11f4101-3432-4d1a-b8bd-d80aa42e5e8e)

</p>
</details>

---

# Changelog

:cl: M3739
- add: A guidebook entry for our four-legged silicon friends is now available.
